### PR TITLE
Fix for Swift when using XCode 10.1

### DIFF
--- a/AppStoreRatings/AppStoreRatings/AppStoreRatings.swift
+++ b/AppStoreRatings/AppStoreRatings/AppStoreRatings.swift
@@ -123,7 +123,7 @@ import StoreKit
      */
     @objc public func debugCurrentStatus(configURL url: URL, completion: @escaping (_ willRequestDialog: Bool, _ launchCountsRemaining: Int, _ daysRemaining: Double, _ wasPreviouslyRequested: Bool, _ error: Error?) -> ()) {
         
-        debugCurrentStatus(configURL: url) { result in
+        debugCurrentStatus(configURL: url) { (result: Result) in
             switch result {
             case let .success(willRequestDialog, launchCountsRemaining, daysRemaining, wasPreviouslyRequested):
                 completion(willRequestDialog, launchCountsRemaining, daysRemaining, wasPreviouslyRequested, nil)


### PR DESCRIPTION
Fixes the error: `Ambiguous use of 'debugCurrentStatus(configURL:completion:)'` when using XCode 10.1.